### PR TITLE
wasapi: fix always defaulting to first device

### DIFF
--- a/src/wasapi.zig
+++ b/src/wasapi.zig
@@ -381,19 +381,17 @@ pub const Context = struct {
             };
 
             try self.devices_info.list.append(self.allocator, device);
-            if (self.devices_info.default(device.mode) == null) {
-                switch (device.mode) {
-                    .playback => if (default_playback_id) |id| {
-                        if (std.mem.eql(u8, device.id, id)) {
-                            self.devices_info.setDefault(.playback, self.devices_info.list.items.len - 1);
-                        }
-                    },
-                    .capture => if (default_capture_id) |id| {
-                        if (std.mem.eql(u8, device.id, id)) {
-                            self.devices_info.setDefault(.capture, self.devices_info.list.items.len - 1);
-                        }
-                    },
-                }
+            switch (device.mode) {
+                .playback => if (default_playback_id) |id| {
+                    if (std.mem.eql(u8, device.id, id)) {
+                        self.devices_info.setDefault(.playback, self.devices_info.list.items.len - 1);
+                    }
+                },
+                .capture => if (default_capture_id) |id| {
+                    if (std.mem.eql(u8, device.id, id)) {
+                        self.devices_info.setDefault(.capture, self.devices_info.list.items.len - 1);
+                    }
+                },
             }
         }
     }


### PR DESCRIPTION
should fix https://github.com/hexops/mach/issues/1016
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.