### PR TITLE
wasapi: Fix memory leak

### DIFF
--- a/src/wasapi.zig
+++ b/src/wasapi.zig
@@ -160,7 +160,9 @@ pub const Context = struct {
     pub fn refresh(ctx: *Context) !void {
         // get default devices id
         const default_playback_id = try ctx.getDefaultAudioEndpoint(.playback);
+        defer ctx.allocator.free(default_playback_id.?);
         const default_capture_id = try ctx.getDefaultAudioEndpoint(.capture);
+        defer ctx.allocator.free(default_capture_id.?);
 
         // enumerate
         var collection: ?*win32.IMMDeviceCollection = null;


### PR DESCRIPTION
The `std.unicode.utf16leToUtf8AllocZ` function used in `getDefaultAudioEndpoint` puts the burden of freeing the memory on the caller (see [1]).

[1] https://ziglang.org/documentation/master/std/#A;std:unicode.utf16leToUtf8AllocZ

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.